### PR TITLE
Updating Ubuntu CI to build Botan from source

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Checkout base repo
         uses: actions/checkout@v4
       - name: Download Botan 3.2
+        uses: actions/checkout@v4
         if:  ${{ matrix.os == 'ubuntu-latest' }}
         with:
           repository: randombit/botan

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -57,8 +57,8 @@ jobs:
         run: |
           sudo apt-get -y update
           sudo apt-get -y install clang build-essential curl libffi-dev libffi8ubuntu1 libgmp-dev libgmp10 libncurses-dev
-          sudo apt-get -y install pkg-config
-          cd ./.botan-work && sudo make && sudo make check && sudo make install
+          sudo apt-get -y install pkg-config python3
+          cd ./.botan-work && sudo python3 ./configure.py && sudo make && sudo make check && sudo make install
       - name: Install Botan for MacOS
         if: ${{ matrix.os == 'macos-latest' }}
         run: |


### PR DESCRIPTION
I noticed that the latest Ubuntu box on github actions is on 22.04 which the botan package is at 2.19 and it looks like in new releases of ubuntu it is still 2.19,  Since it was a little disheartening to see the linux ci fail, I updated it to pull down botan 3.2.0 from source, build it, and install it. this should fix a couple of the failing linux builds on the main-ci run. it looks like ghc 9.2.8 and ghc 9.0.2 are still failing for linux.